### PR TITLE
Exposing some more information from the eNet server

### DIFF
--- a/custom_components/enet/aioenet.py
+++ b/custom_components/enet/aioenet.py
@@ -52,6 +52,7 @@ class EnetClient:
         self._cookie = ""
         self._last_telegram_ts = {}
         self._raw_json = {}
+        self._projectuid = None
         self.devices = []
 
     @auth_if_needed
@@ -109,6 +110,23 @@ class EnetClient:
         await self.request(URL_MANAGEMENT, "userLogout", None)
         await self._session.close()
 
+    async def get_project(self):
+        """Get the project which included the projectUID and the projectName"""
+        result = await self.request(URL_VIZ, "getCurrentProject", None)
+        self._projectuid = result["projectUID"]
+        return result
+
+    async def get_project_information(self):
+        """Get the project information which includes version numbers, 
+        creation and modification dates and other general information
+        about the server and its configuration."""
+        if self._projectuid is None:
+            result = await self.get_project()
+        
+        params = {"projectUID": self._projectuid}
+        result = await self.request(URL_VIZ, "getProjectInformation", params)
+        return result
+    
     def get_account(self):
         """Return the current logged in user account"""
         return self.request(URL_MANAGEMENT, "getAccount", {})


### PR DESCRIPTION
Hello Magnus,

I added two methods for exposing some more information from the eNet server. I found this by snooping the traffic between browser and eNet server. It contains the modification date of the setup which I would like to use when implementing the cached files (speeding up startup time and load on eNet server). 

Do you envision the eNet library to be on this level or would you go for a "higher" level. Instead of these two methods returning the JSON, it could also be methods like "get_last_modification_time()" and "get_server_version()". Or of course both.

How do you envision this?

Regards,

Marcel