### PR TITLE
Adding get_all_location_uids()

### DIFF
--- a/custom_components/enet/aioenet.py
+++ b/custom_components/enet/aioenet.py
@@ -410,7 +410,7 @@ class Actuator(BaseEnetDevice):
                     self.channels.append(Channel(self, device_channel))
 
     def __repr__(self):
-        return f"{self.__class__.__name__} (Name: {self.name} Type: {self.device_type}"
+        return f"{self.__class__.__name__} (Name: {self.name} Type: {self.device_type})"
 
 
 class Channel:
@@ -462,7 +462,7 @@ class Channel:
         return main_func
 
     async def get_value(self):
-        """Fetch the updated state from the sever"""
+        """Fetch the updated state from the server"""
         params = {"deviceFunctionUID": self.output_device_function["uid"]}
         current_value = await self.device.client.request(
             URL_VIZ, "getCurrentValuesFromOutputDeviceFunction", params


### PR DESCRIPTION
The existing get_device_locations() exposes the link between devices and locationuid.

However, I was missing something from the Actuator class. The location of the Actuator might the Fuse Box, but its channels control something usually in a room in the house. There was also an Effective Location UID of the channel of the Actuator but this name was not available with get_device_locations(). 

I added get_all_location_uids() to map every location with its UID. This are used for the actual actuators locations and the actual sensor location but also for certain channels which can be configured to be in another location (and are also shown like this in the eNet App for smart phones).
