### PR TITLE
Adds DVT_TADO device and add TADO channels to 'ignored_channel_types'…

### DIFF
--- a/custom_components/enet/enet_devices.py
+++ b/custom_components/enet/enet_devices.py
@@ -220,6 +220,11 @@ device_info = {
         "manufacturer": "Gira",
         "device_class": None,
     },
+    "DVT_TADO": {
+        "description": "enet integrated TADO",
+        "manufacturer": "TADO",
+        "device_class": None,
+    },
 }
 
 channel_config = {
@@ -339,4 +344,4 @@ channel_config = {
     "CT_1F20": {"description": "Repeater sensor", "type": "sensor"},
 }
 
-ignored_channel_types = ("CT_DISABLED", "CT_DEVICE", "CT_1F15")
+ignored_channel_types = ("CT_DISABLED", "CT_DEVICE", "CT_1F15", "CH_TADO", "CH_TADO_ZH")


### PR DESCRIPTION
… in enet_devices.py.

This ensures that eNET installations with TADO integration don't report errors during installation and startup of the enet-homeassistant custom_component. Given that there's a working integration for TADO in homeassistant, there's no need for control of TADO through the enet-homeassistant custom_component.