### PR TITLE
Switches and Battery Sensor

### DIFF
--- a/custom_components/enet/__init__.py
+++ b/custom_components/enet/__init__.py
@@ -23,6 +23,7 @@ PLATFORMS: list[Platform] = [
     Platform.SCENE,
     Platform.COVER,
     Platform.SENSOR,
+    Platform.SWITCH
 ]
 
 EVENT_TYPE_CHANNELS = [

--- a/custom_components/enet/__init__.py
+++ b/custom_components/enet/__init__.py
@@ -32,9 +32,11 @@ EVENT_TYPE_CHANNELS = [
     ChannelTypeFunctionName.SCENE_CONTROL,
     ChannelTypeFunctionName.TRIGGER_START
 ]
+EVENT_DEVICE_BATTERY_STATE_CHANGED = "deviceBatteryStateChanged"
 EVENT_OUTPUT_DEVICE_FUNCTION_CALLED = "outputDeviceFunctionCalled"
-VALUE_TYPE_ROCKER_STATE = "VT_ROCKER_STATE"
-VALUE_TYPE_ROCKER_SWITCH_TIME = "VT_ROCKER_SWITCH_TIME"
+EVENT_VALUE_TYPE_ROCKER_STATE = "VT_ROCKER_STATE"
+EVENT_VALUE_TYPE_ROCKER_SWITCH_TIME = "VT_ROCKER_SWITCH_TIME"
+EVENT_VALUE_DOWN_BUTTON = "DOWN_BUTTON"
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Enet Smart Home from a config entry."""
@@ -95,6 +97,7 @@ class EnetCoordinator(DataUpdateCoordinator):
     async def setup_event_listeners(self) -> None:
         """Setup event listener for all output functions"""
         _LOGGER.debug("Setting up event listeners")
+        await self.hub.setup_event_subscription_battery_state()
         for device in self.hub.devices:
             func_uids = device.get_function_uids_for_event()
             self.function_uid_map.update(func_uids)
@@ -144,12 +147,12 @@ class EnetCoordinator(DataUpdateCoordinator):
                         continue
 
                     event_type = EVENT_TYPE_INITIAL_PRESS
-                    if values[0]["valueTypeID"] == VALUE_TYPE_ROCKER_STATE:
+                    if values[0]["valueTypeID"] == EVENT_VALUE_TYPE_ROCKER_STATE:
                         # If a button is configured as a rocker, you have the UP and Down
                         # button on the same channel.
-                        if values[0]["value"] == "DOWN_BUTTON":
+                        if values[0]["value"] == EVENT_VALUE_DOWN_BUTTON:
                             subtype += 1
-                    if values[1]["valueTypeID"] == VALUE_TYPE_ROCKER_SWITCH_TIME:
+                    if values[1]["valueTypeID"] == EVENT_VALUE_TYPE_ROCKER_SWITCH_TIME:
                         # Switch time is 0 on press and a number for release.
                         # We don't distinguish between long and short press for the
                         # moment.
@@ -163,3 +166,12 @@ class EnetCoordinator(DataUpdateCoordinator):
                         "subtype": subtype,
                     }
                     self.hass.bus.async_fire(ATTR_ENET_EVENT, bus_data)
+            elif event["event"] == EVENT_DEVICE_BATTERY_STATE_CHANGED:
+                # _LOGGER.debug("Battery state changed: %s", event["eventData"])
+                data = event["eventData"]
+                device_uid = data.get("deviceUID", None)
+                battery_state = data.get("batteryState", None)
+                device = next((d for d in self.hub.devices if d.uid == device_uid), None)
+                if device:
+                    device.update_battery_state(battery_state)
+                    self.async_update_listeners()

--- a/custom_components/enet/cover.py
+++ b/custom_components/enet/cover.py
@@ -10,7 +10,7 @@ from homeassistant.components.cover import (
 )
 
 from custom_components.enet.enet_data.enums import ChannelApplicationMode, ChannelTypeFunctionName
-from .entity import EnetBaseEntity
+from .entity import EnetBaseChannelEntity
 from .aioenet import ActuatorChannel
 from .const import DOMAIN
 
@@ -32,7 +32,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     _LOGGER.info("Finished async setup()")
 
 
-class EnetCover(EnetBaseEntity, CoverEntity):
+class EnetCover(EnetBaseChannelEntity, CoverEntity):
     """A representation of an Enet Smart Home cover / blinds channel"""
 
     def __init__(self, channel, coordinator):

--- a/custom_components/enet/enet_data/enums.py
+++ b/custom_components/enet/enet_data/enums.py
@@ -71,3 +71,9 @@ class ChannelTypeFunctionName(StrEnum):
     TRIGGER_START = "triggerStart"
     UP_DOWN = "upDown"
     VOLTAGE = "voltage"
+
+@unique
+class DeviceBatteryState(StrEnum):
+    NO_STATE = "NO_STATE",
+    BATTERY_OK = "BATTERY_OK",
+    BATTERY_WEAK = "BATTERY_WEAK"

--- a/custom_components/enet/entity.py
+++ b/custom_components/enet/entity.py
@@ -39,24 +39,13 @@ class EnetBaseChannelEntity(EnetBaseEntity, Entity):
     def device_info(self):
         """Return the device information."""
         return self.channel.device.get_device_info()
+
 class EnetBaseDeviceEntity(EnetBaseEntity, Entity):
     """Generic Entity Class for Enet Smart Home devices"""
 
     def __init__(self, device, coordinator):
-        self._name = device.name
         self.device = device
         self.coordinator = coordinator
-        _LOGGER.info("Enet entity %s", self._name)
-
-    @property
-    def unique_id(self):
-        """Return a unique ID."""
-        return self.device.uid
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
 
     @property
     def device_info(self):

--- a/custom_components/enet/entity.py
+++ b/custom_components/enet/entity.py
@@ -4,20 +4,26 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-
 class EnetBaseEntity(Entity):
-    """Generic Entity Class for Enet Smart Home devices"""
+    """Generic Entity Class for Enet Smart Home entities"""
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return True
+
+    @property
+    def should_poll(self):
+        """Return the polling state. False means the entity will only update when it has new data."""
+        return False
+
+class EnetBaseChannelEntity(EnetBaseEntity, Entity):
+    """Generic Entity Class for Enet Smart Home channel"""
 
     def __init__(self, channel, coordinator):
         self._name = channel.name
         self.channel = channel
         self.coordinator = coordinator
         _LOGGER.info("Enet entity %s", self._name)
-
-    @property
-    def available(self):
-        """Return True if entity is available."""
-        return True
 
     @property
     def unique_id(self):
@@ -33,8 +39,26 @@ class EnetBaseEntity(Entity):
     def device_info(self):
         """Return the device information."""
         return self.channel.device.get_device_info()
+class EnetBaseDeviceEntity(EnetBaseEntity, Entity):
+    """Generic Entity Class for Enet Smart Home devices"""
+
+    def __init__(self, device, coordinator):
+        self._name = device.name
+        self.device = device
+        self.coordinator = coordinator
+        _LOGGER.info("Enet entity %s", self._name)
 
     @property
-    def should_poll(self):
-        """Return the polling state. False means the entity will only update when it has new data."""
-        return False
+    def unique_id(self):
+        """Return a unique ID."""
+        return self.device.uid
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def device_info(self):
+        """Return the device information."""
+        return self.device.get_device_info()

--- a/custom_components/enet/light.py
+++ b/custom_components/enet/light.py
@@ -19,7 +19,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
     hub = hass.data[DOMAIN][entry.entry_id]
 
     supported_app_modes = [
-        ChannelApplicationMode.SWITCHING,
         ChannelApplicationMode.LIGHT_SWITCHING,
         ChannelApplicationMode.LIGHT_DIMMING,
     ]

--- a/custom_components/enet/light.py
+++ b/custom_components/enet/light.py
@@ -7,7 +7,7 @@ from homeassistant.util.scaling import scale_ranged_value_to_int_range
 
 from custom_components.enet.enet_data.enums import ChannelApplicationMode, ChannelTypeFunctionName
 
-from .entity import EnetBaseEntity
+from .entity import EnetBaseChannelEntity
 from .aioenet import ActuatorChannel
 from .const import DOMAIN
 
@@ -30,7 +30,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     _LOGGER.info("Finished async setup()")
 
 
-class EnetLight(EnetBaseEntity, LightEntity):
+class EnetLight(EnetBaseChannelEntity, LightEntity):
     """A representation of a Enet Smart Home dimmer or switch channel"""
 
     @property

--- a/custom_components/enet/sensor.py
+++ b/custom_components/enet/sensor.py
@@ -76,6 +76,24 @@ class EnetBatterySensor(EnetBaseDeviceEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.ENUM
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_options = [state.value for state in DeviceBatteryState]
+    _attr_has_entity_name = True
+
+    def __init__(self, device, coordinator):
+        super().__init__(
+            device,
+            coordinator
+        )
+        self._uid = f"{self.device.uid}_battery_state"
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._uid
+
+    @property
+    def translation_key(self):
+        """Return the translation key to translate the entity's name and states."""
+        return "battery_state"
 
     @property
     def native_value(self) -> int:

--- a/custom_components/enet/strings.json
+++ b/custom_components/enet/strings.json
@@ -18,6 +18,18 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
+  "entity": {
+    "sensor": {
+      "battery_state": {
+        "name": "Battery state String",
+        "state": {
+          "NO_STATE": "Unknown",
+          "BATTERY_OK": "Ok",
+          "BATTERY_WEAK": "Weak"
+        }
+      }
+    }
+  },
   "device_automation": {
     "trigger_subtype": {
       "1": "Button 1",

--- a/custom_components/enet/switch.py
+++ b/custom_components/enet/switch.py
@@ -5,7 +5,7 @@ from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass
 
 from custom_components.enet.enet_data.enums import ChannelApplicationMode, ChannelTypeFunctionName
 
-from .entity import EnetBaseEntity
+from .entity import EnetBaseChannelEntity
 from .aioenet import ActuatorChannel
 from .const import DOMAIN
 
@@ -27,7 +27,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     _LOGGER.info("Finished async setup()")
 
 
-class EnetSwitch(EnetBaseEntity, SwitchEntity):
+class EnetSwitch(EnetBaseChannelEntity, SwitchEntity):
     """A representation of a Enet Smart Home switch channel"""
 
     def __init__(self, channel, coordinator):

--- a/custom_components/enet/switch.py
+++ b/custom_components/enet/switch.py
@@ -1,0 +1,59 @@
+"""Enet Smart Home switch support"""
+import logging
+
+from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass
+
+from custom_components.enet.enet_data.enums import ChannelApplicationMode, ChannelTypeFunctionName
+
+from .entity import EnetBaseEntity
+from .aioenet import ActuatorChannel
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Add Enet switch devices from a config entry"""
+    hub = hass.data[DOMAIN][entry.entry_id]
+
+    supported_app_modes = [
+        ChannelApplicationMode.SWITCHING
+    ]
+
+    for device in hub.devices:
+        for channel in device.channels:
+            if isinstance(channel, ActuatorChannel) and channel.application_mode in supported_app_modes:
+                async_add_entities([EnetSwitch(channel, hub.coordinator)])
+    _LOGGER.info("Finished async setup()")
+
+
+class EnetSwitch(EnetBaseEntity, SwitchEntity):
+    """A representation of a Enet Smart Home switch channel"""
+
+    def __init__(self, channel, coordinator):
+        super().__init__(channel, coordinator)
+        self._attr_device_class = SwitchDeviceClass.SWITCH
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self.channel.get_current_value(ChannelTypeFunctionName.ON_OFF)
+
+    async def async_added_to_hass(self):
+        """Subscribe entity to updates when added to hass."""
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self.async_write_ha_state)
+        )
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the switch on."""
+        _LOGGER.info("async_turn_on: (%s) %s", self.name, kwargs)
+
+        await self.channel.turn_on()
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the switch off."""
+        _LOGGER.info("async_turn_off: (%s) %s", self.name, kwargs)
+        await self.channel.turn_off()
+        self.async_write_ha_state()

--- a/custom_components/enet/translations/de.json
+++ b/custom_components/enet/translations/de.json
@@ -1,0 +1,50 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Das Gerät ist bereits konfiguriert."
+        },
+        "error": {
+            "cannot_connect": "Verbindungsfehler",
+            "invalid_auth": "Ungültige Zugangsdaten",
+            "unknown": "Unerwarteter Fehler"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "password": "Passwort",
+                    "url": "URL",
+                    "username": "Benutzername"
+                }
+            }
+        }
+    },
+    "entity": {
+    "sensor": {
+      "battery_state": {
+        "name": "Batterie-Status",
+        "state": {
+          "NO_STATE": "Unbekannt",
+          "BATTERY_OK": "Ok",
+          "BATTERY_WEAK": "Schwach"
+        }
+      }
+    }
+  },
+    "device_automation": {
+        "trigger_subtype": {
+            "1": "Schalter 1",
+            "2": "Schalter 2",
+            "3": "Schalter 3",
+            "4": "Schalter 4",
+            "5": "Schalter 5",
+            "6": "Schalter 6",
+            "7": "Schalter 7",
+            "8": "Schalter 8"
+        },
+        "trigger_type": {
+            "initial_press": "\"{subtype}\" wurde gedrückt",
+            "long_release": "\"{subtype}\" wurde nach langem Drücken losgelassen",
+            "short_release": "\"{subtype}\" wurde nach kurzem Drücken losgelassen"
+        }
+    }
+}

--- a/custom_components/enet/translations/en.json
+++ b/custom_components/enet/translations/en.json
@@ -18,6 +18,18 @@
             }
         }
     },
+    "entity": {
+    "sensor": {
+      "battery_state": {
+        "name": "Battery state",
+        "state": {
+          "NO_STATE": "Unknown",
+          "BATTERY_OK": "Ok",
+          "BATTERY_WEAK": "Weak"
+        }
+      }
+    }
+  },
     "device_automation": {
         "trigger_subtype": {
             "1": "Button 1",


### PR DESCRIPTION
Hi Magnus!

Since you merged already my previous PR, I've 2 subsequent features already implemented :)

1. Add Switch Domain:
   Actuators that are configured as switches (ChannelApplicationMode.SWITCHING) instead of light switches (ChannelApplicationMode.LIGHT_SWITCHING) or light dimmers (ChannelApplicationMode.LIGHT_DIMMING) will now correctly be represented as switches and not lights
   **IMPORTANT:** This is a **breaking change** für already existing entities with ChannelApplicationMode.SWITCHING, since they will be moved from light domain to switch domain. This results in the entities being newly created as switches, while the "old lights" will have to be removed manually from HA
2. Add Battery State Sensor for devices that have one
3. Added translation for German

**Testing:**
I'currently testing with my own eNet setup at home:
Server-Version: 2.4.0
Server-Hardware: 2
Home-Assistant: HA 2024.5.4

**DeviceTypes:**
DVT_DA1M
DVT_US2M
DVT_SA1M
DVT_SA2M
DVT_SD1M
DVT_SF1S
DVT_SV1M
DVT_JA1M
DVT_WS1BG
DVT_WS3BG